### PR TITLE
[Feat] 상세페이지 화면 구현

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2024-06-12T07:43:02.773297Z">
+        <DropdownSelection timestamp="2024-06-20T07:37:48.535763Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=/Users/choimaro/.android/avd/Nexus_5_API_33.avd" />

--- a/app/src/main/java/com/choimaro/technical_task_android/component/ComposableComponent.kt
+++ b/app/src/main/java/com/choimaro/technical_task_android/component/ComposableComponent.kt
@@ -25,7 +25,7 @@ fun ImageModelItem(imageModel: ImageModel, imageModifier: Modifier) {
             modifier = imageModifier,
             contentScale = ContentScale.Crop
         )
-        Text(text = "${imageModel.displaySiteName}")
-        imageModel.datetime?.let { Text(text = it) }
+        Text(text = imageModel.displaySiteName)
+        Text(text = imageModel.datetime)
     }
 }

--- a/app/src/main/java/com/choimaro/technical_task_android/home/view/screen/ImageDetailScreen.kt
+++ b/app/src/main/java/com/choimaro/technical_task_android/home/view/screen/ImageDetailScreen.kt
@@ -1,13 +1,26 @@
 package com.choimaro.technical_task_android.home.view.screen
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.choimaro.domain.model.ImageModel
+import com.choimaro.technical_task_android.component.ImageModelItem
 import com.choimaro.technical_task_android.home.viewmodel.MainViewModel
 
 @Composable
@@ -15,7 +28,25 @@ fun ImageDetailScreen(
     imageModel: ImageModel,
     navHostController: NavHostController,
     viewModel: MainViewModel = hiltViewModel()) {
-    Column(modifier = Modifier.fillMaxSize()) {
-        Text(text = "ImageDetailScreen")
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(8.dp),
+        elevation = CardDefaults.cardElevation(6.dp)
+    ){
+        BoxWithConstraints(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.TopEnd
+        ) {
+            val screenHeight = maxHeight
+            val halfScreenHeight = screenHeight / 2
+
+            ImageModelItem(
+                imageModel = imageModel,
+                imageModifier = Modifier
+                    .height(halfScreenHeight)
+                    .fillMaxWidth()
+                    .clip(shape = RoundedCornerShape(8.dp))
+            )
+        }
     }
 }


### PR DESCRIPTION
상세페이지 화면 구현

### 동작
검색 화면 또는 저장한 북마크 화면에서 이미지를 클릭 시 상세 페이지로 이동합니다.

### 결과
<img width="274" alt="image" src="https://github.com/CHOIMARO/technical_task_android/assets/53159069/f4833647-726a-45c6-aaab-848a01c4f162">
